### PR TITLE
Implement new tx creation.

### DIFF
--- a/mobile/accounts_test.go
+++ b/mobile/accounts_test.go
@@ -1,0 +1,49 @@
+package geth
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+)
+
+func TestSignTx(t *testing.T) {
+	from := "0xb008e10e6633befd086028691ecc70648b288689"
+	to := "0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb"
+	nonce := int64(1)
+	gas := int64(21000)
+	maxFeePerGas := NewBigInt(10000000000)
+	maxPriorityFeePerGas := NewBigInt(10000000000)
+	value := NewBigInt(0)
+	chainId := NewBigInt(1)
+	data := common.FromHex("0xa9059cbb000000000000000000000000b008e10e6633befd086028691ecc70648b28868900000000000000000000000000000000000000000000000000b1a2bc2ec50000")
+
+	fromAddress := Address{
+		address: common.HexToAddress(from),
+	}
+	toAddress := Address{
+		address: common.HexToAddress(to),
+	}
+
+	tx := NewTransaction(&fromAddress, &toAddress, nonce, gas, maxFeePerGas, maxPriorityFeePerGas, value, chainId, data)
+
+	tmpDir := t.TempDir()
+	tmpDirPath, _ := filepath.Abs(tmpDir)
+	ks := NewKeyStore(tmpDirPath, 2, 1)
+
+	pass := "" // not used but required by API
+	a1, err1 := ks.NewAccount(pass)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if err := ks.Unlock(a1, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	signed, err2 := ks.SignTx(a1, tx, NewBigInt(1))
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	assert.NotEqual(t, nil, signed)
+}

--- a/mobile/ethclient.go
+++ b/mobile/ethclient.go
@@ -313,3 +313,11 @@ func (ec *EthereumClient) EstimateGas(ctx *Context, msg *CallMsg) (gas int64, _ 
 func (ec *EthereumClient) SendTransaction(ctx *Context, tx *Transaction) error {
 	return ec.client.SendTransaction(ctx.context, tx.tx)
 }
+
+// SuggestGasTipCap retrieves the currently suggested gas tip cap after 1559 to
+// allow a timely execution of a transaction.
+// Under the hood it calls `eth_maxPriorityFeePerGas`.
+func (ec *EthereumClient) SuggestGasTipCap(ctx *Context) (gas *BigInt, _ error) {
+	rawGas, err := ec.client.SuggestGasTipCap(ctx.context)
+	return &BigInt{rawGas}, err
+}

--- a/mobile/types_test.go
+++ b/mobile/types_test.go
@@ -1,0 +1,61 @@
+package geth
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewTransaction(t *testing.T) {
+	from := "0xb008e10e6633befd086028691ecc70648b288689"
+	to := "0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb"
+	nonce := int64(1)
+	gas := int64(21000)
+	maxFeePerGas := NewBigInt(10000000000)
+	maxPriorityFeePerGas := NewBigInt(10000000000)
+	value := NewBigInt(0)
+	chainId := NewBigInt(1)
+	data := common.FromHex("0xa9059cbb000000000000000000000000b008e10e6633befd086028691ecc70648b28868900000000000000000000000000000000000000000000000000b1a2bc2ec50000")
+
+	fromAddress := Address{
+		address: common.HexToAddress(from),
+	}
+	toAddress := Address{
+		address: common.HexToAddress(to),
+	}
+
+	tx := NewTransaction(&fromAddress, &toAddress, nonce, gas, maxFeePerGas, maxPriorityFeePerGas, value, chainId, data)
+
+	str, err := tx.EncodeJSON()
+
+	expectedJson := "{\"type\":\"0x2\",\"nonce\":\"0x1\",\"gasPrice\":null,\"maxPriorityFeePerGas\":\"0x2540be400\",\"maxFeePerGas\":\"0x2540be400\",\"gas\":\"0x5208\",\"value\":\"0x0\",\"input\":\"0xa9059cbb000000000000000000000000b008e10e6633befd086028691ecc70648b28868900000000000000000000000000000000000000000000000000b1a2bc2ec50000\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"to\":\"0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb\",\"chainId\":\"0x1\",\"accessList\":[],\"hash\":\"0xaf85ec87dc6bc9c993bfcfa18692c52adea59cc5503a58443b0d054b8951fc70\"}"
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedJson, str)
+}
+
+func TestNewTransaction_NoFees(t *testing.T) {
+	from := "0xb008e10e6633befd086028691ecc70648b288689"
+	to := "0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb"
+	nonce := int64(1)
+	gas := int64(21000)
+	value := NewBigInt(0)
+	chainId := NewBigInt(1)
+	data := common.FromHex("0xa9059cbb000000000000000000000000b008e10e6633befd086028691ecc70648b28868900000000000000000000000000000000000000000000000000b1a2bc2ec50000")
+
+	fromAddress := Address{
+		address: common.HexToAddress(from),
+	}
+	toAddress := Address{
+		address: common.HexToAddress(to),
+	}
+
+	tx := NewTransaction(&fromAddress, &toAddress, nonce, gas, nil, nil, value, chainId, data)
+
+	str, err := tx.EncodeJSON()
+
+	expectedJson := "{\"type\":\"0x2\",\"nonce\":\"0x1\",\"gasPrice\":null,\"gas\":\"0x5208\",\"value\":\"0x0\",\"input\":\"0xa9059cbb000000000000000000000000b008e10e6633befd086028691ecc70648b28868900000000000000000000000000000000000000000000000000b1a2bc2ec50000\",\"v\":\"0x0\",\"r\":\"0x0\",\"s\":\"0x0\",\"to\":\"0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb\",\"chainId\":\"0x1\",\"accessList\":[],\"hash\":\"0xaf85ec87dc6bc9c993bfcfa18692c52adea59cc5503a58443b0d054b8951fc70\"}"
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedJson, str)
+}


### PR DESCRIPTION
EIP-1559

Старый метод `EthereumClient.newTransaction(...)` переименован в `newLegacyTransaction(...)`.
Для EIP-1559 транзакций добавлен метод `newTransaction(...)`.

Для транзакций из веба не стоит пересчитывать maxPriorityFeePerGas или maxFeePerGas, если их нет, так как это может повлечь за собой неожиданные расходы со стороны пользователя.
Подробнее: https://docs.alchemy.com/alchemy/guides/eip-1559/maxpriorityfeepergas-vs-maxfeepergas

Для подсчёта `maxPriorityFeePerGas` в `Geth` добавлен метод `EthereumClient.suggestGasTipCap(ctx)`, который под капотом вызывает RPC-метод `eth_maxPriorityFeePerGas`.

Для подписи новых транзакций обязательно нужно указать текущий `chainId`, иначе при вызове `signTx(...)` вывалится ошибка "transaction type not supported".